### PR TITLE
Esc 57 front create components for new feed

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -32,6 +32,7 @@
     "no-unused-vars": "warn",
     "no-var": "warn",
     "no-console": "warn",
-    "no-debugger": "warn"
+    "no-debugger": "warn",
+    "import/no-unresolved": "off"
   }
 }

--- a/src/components/atoms/Img/index.js
+++ b/src/components/atoms/Img/index.js
@@ -17,8 +17,8 @@ Img.propTypes = {
 Img.defaultProps = {
   alt: "picture",
   src: "https://static01.nyt.com/images/2021/09/14/science/07CAT-STRIPES/07CAT-STRIPES-mediumSquareAt3X-v2.jpg",
-  width: "10%",
-  height: "10%",
+  width: "100%",
+  height: "100%",
 };
 
 export default Img;

--- a/src/components/atoms/icon/index.js
+++ b/src/components/atoms/icon/index.js
@@ -23,6 +23,9 @@ import {
   IoChatbubbleOutline,
   IoChatbubble,
   IoChatbubbleSharp,
+  IoClose,
+  IoCloseOutline,
+  IoCloseSharp,
   IoPaperPlaneOutline,
   IoPaperPlane,
   IoPaperPlaneSharp,
@@ -36,6 +39,8 @@ import {
   IoWalk,
   IoWalkSharp,
 } from "react-icons/io5";
+import { MdSaveAlt } from "react-icons/md";
+
 import { noop } from "lodash";
 
 function getSize(size) {
@@ -96,8 +101,8 @@ function Icon({ icon, size, onClickIcon, ...props }) {
     case "myPage":
       svg = <IoPersonOutline />; // <IoPerson />; or <IoPersonSharp />;
       break;
-    case "saveFeed":
-      svg = <IoCloudUploadOutline />; // <IoCloudUpload />; or <IoCloudUploadSharp />;
+    case "save":
+      svg = <MdSaveAlt />; // <IoCloudUpload />; or <IoCloudUploadSharp />;
       break;
     case "likeLine":
       svg = <IoHeartOutline />;
@@ -108,11 +113,11 @@ function Icon({ icon, size, onClickIcon, ...props }) {
     case "comment":
       svg = <IoChatbubbleOutline />; // <IoChatbubble />; or <IoChatbubbleSharp />;
       break;
-    case "saveComment":
+    case "send":
       svg = <IoPaperPlaneOutline />; // <IoPaperPlane />; or <IoPaperPlaneSharp />;
       break;
     case "location":
-      svg = <IoLocationOutline />; // <IoLocation />; or <IoLocationSharp />;
+      svg = <IoLocationSharp />; // <IoLocation />; or <IoLocationSharp />;
       break;
     case "trashCanLine":
       svg = <IoTrashOutline />;
@@ -122,6 +127,9 @@ function Icon({ icon, size, onClickIcon, ...props }) {
       break;
     case "movingPerson":
       svg = <IoWalkOutline />;
+      break;
+    case "close":
+      svg = <IoCloseOutline />;
       break;
     default:
       console.log("Check icon type!!!");

--- a/src/components/atoms/textarea/index.js
+++ b/src/components/atoms/textarea/index.js
@@ -6,12 +6,17 @@ import themes from "../../../theme/theme";
 const { fontSizes, paddings } = themes;
 
 const StyledTextarea = styled.textarea`
+  display: inline-block;
   width: ${(props) => props.width};
   height: ${(props) => props.height};
   font-size: ${(props) => props.fontSize};
   padding: ${(props) => props.padding};
+  box-sizing: border-box;
   border-width: ${(props) => props.borderWidth};
+  border-radius: ${(props) => props.radius};
+  background: ${({ theme, background }) => theme.colors[background]};
   resize: none;
+  outline: none;
 `;
 
 function Textarea({ ...props }) {
@@ -27,8 +32,8 @@ Textarea.propTypes = {
 };
 
 Textarea.defaultProps = {
-  width: "300px",
-  heigth: "500px",
+  width: "100%",
+  heigth: "100%",
   fontSize: fontSizes.base,
   padding: paddings.xl,
   borderWidth: "0.5rem",

--- a/src/components/molecules/FeedHeader/index.js
+++ b/src/components/molecules/FeedHeader/index.js
@@ -7,6 +7,7 @@ import { Avatar, Text } from "../../atoms";
 const StyledContainer = styled.div`
   display: inline-flex;
   padding: 0.8rem;
+  padding-right: 0;
   width: 100%;
 `;
 

--- a/src/components/organisms/NewFeedModal/index.js
+++ b/src/components/organisms/NewFeedModal/index.js
@@ -1,0 +1,91 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+import styled from "styled-components";
+
+import { Img, Icon, Textarea, Input } from "../../atoms";
+import { FeedHeader } from "../../molecules";
+import themes from "../../../theme/theme";
+
+const { colors } = themes;
+
+const Container = styled.div`
+  display: flex;
+  width: 90rem;
+  height: 60rem;
+  background: ${({ theme }) => theme.colors.white};
+`;
+
+const ImageWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  width: 50rem;
+  height: 100%;
+  background: ${({ theme }) => theme.opacityColor.gray};
+`;
+
+const ContentsWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 40rem;
+  height: 100%;
+  padding: 1rem;
+`;
+
+const CloseWrapper = styled.div`
+  width: 100%;
+  text-align: right;
+  margin-bottom: 2rem;
+`;
+
+const HeaderWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  width: 100%;
+  margin-bottom: 1rem;
+  padding-left: 1rem;
+  padding-right: 2rem;
+`;
+
+const AddressWrapper = styled.div`
+  display: flex;
+  width: 90%;
+  margin-top: 2rem;
+  text-align: right;
+`;
+
+const AddressInput = styled(Input)`
+  width: 100%;
+  border: none;
+  border-bottom: 1px solid ${({ theme }) => theme.colors.gray_2};
+  outline: none;
+`;
+
+function NewFeedModal() {
+  const imgSrc = "https://www.vanillacoding.co/images/team/ken.jpg";
+  return (
+    <Container>
+      <ImageWrapper>
+        <Img alt="feed image" src={imgSrc} />
+      </ImageWrapper>
+      <ContentsWrapper>
+        <CloseWrapper>
+          <Icon icon="close" size="md" />
+        </CloseWrapper>
+        <HeaderWrapper>
+          <FeedHeader nickname="Ken" address="Seoul, Korea" url={imgSrc} />
+          <Icon icon="save" size="sm" />
+        </HeaderWrapper>
+        <Textarea background="gray_4" borderWidth={0} radius="0.6rem" width="90%" height="18rem" />
+        <AddressWrapper>
+          <Icon icon="location" size="md" fill={colors.gray_3} />
+          <AddressInput />
+        </AddressWrapper>
+      </ContentsWrapper>
+    </Container>
+  );
+}
+
+export default NewFeedModal;

--- a/src/components/organisms/index.js
+++ b/src/components/organisms/index.js
@@ -2,5 +2,6 @@ import FeedCard from "./FeedCard";
 import Header from "./Header";
 import RankingList from "./RankingList";
 import UserInfo from "./UserInfo";
+import NewFeedModal from "./NewFeedModal";
 
-export { FeedCard, Header, RankingList, UserInfo };
+export { FeedCard, Header, RankingList, UserInfo, NewFeedModal };

--- a/src/theme/theme.js
+++ b/src/theme/theme.js
@@ -48,6 +48,7 @@ const colors = {
   gray_1: "#F0EDED",
   gray_2: "#e5e4e4",
   gray_3: "#8C8A8A",
+  gray_4: "#ebe9e9ba",
   green_1: "#5CC793",
   green_2: "#3cb46e",
   red: "#D16D6A",


### PR DESCRIPTION
# [ESC 57] Create components for new feed

## jira 칸반 링크
- [[Front]Create components for new feed](https://earth-saving-cleaner.atlassian.net/browse/ESC-57)

## 카드에서 구현 혹은 해결하려는 내용
- NewFeedModal organisms 생성
- atoms 컴포넌트 스타일 수정 (Icon, Img, Textarea, Input)
- eslint 'import/no-unresolved' rule 추가

## 테스트 방법
- 렌더링 테스트
  - `import { NewFeedModal } from  "oranisms 폴더"`
  - NewFeedModal 렌더

## 기타 사항
- 아이콘 중에 피드 저장과 댓글 보내기 이름이 각 saveFeed, saveComment로 되어 있어서 제너럴한 이름 save, send로 변경했습니다.
- 피드 등록 모달은 우선 organism으로 만들었습니다. 조금 더 작은 컴포넌트로 분리가 가능할 것 같은데 현재는 등록 모달에서만 사용하는 컴포넌트로 보여서 기능 개발이 진행된 이후에 고민해보면 좋을 것 같습니다.
- mock data로 화면을 그리고 있습니다(추후에 handler 함수가 들어오면 제거될 예정)
