### PR TITLE
[ESC 123] front header add event handler

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -33,6 +33,7 @@
     "no-var": "warn",
     "no-console": "warn",
     "no-debugger": "warn",
-    "import/no-unresolved": "off"
+    "import/no-unresolved": "off",
+    "no-unused-expressions": "off"
   }
 }

--- a/src/components/molecules/Navigation/index.js
+++ b/src/components/molecules/Navigation/index.js
@@ -4,6 +4,7 @@ import PropTypes from "prop-types";
 
 import Icon from "../../atoms/Icon";
 import themes from "../../../theme/theme";
+import { noop } from "lodash";
 
 const StyledNavigation = styled.div`
   width: 5rem;
@@ -18,9 +19,9 @@ const StyledNavigation = styled.div`
   `}
 `;
 
-function Navigation({ ...props }) {
+function Navigation({ onNavClick, ...props }) {
   return (
-    <StyledNavigation {...props}>
+    <StyledNavigation onClick={onNavClick} {...props}>
       <Icon icon={props.iconType} {...props} />
     </StyledNavigation>
   );
@@ -31,12 +32,14 @@ Navigation.propTypes = {
   isSelected: PropTypes.bool,
   size: PropTypes.string,
   stroke: PropTypes.string,
+  onNavClick: PropTypes.func,
 };
 
 Navigation.defaultProps = {
   isSelected: false,
   size: "sm",
   stroke: themes.colors.white,
+  onNavClick: noop,
 };
 
 export default Navigation;

--- a/src/components/organisms/Header/index.js
+++ b/src/components/organisms/Header/index.js
@@ -1,7 +1,7 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import styled from "styled-components";
 import PropTypes from "prop-types";
-import { useHistory } from "react-router-dom";
+import { useHistory, useLocation } from "react-router-dom";
 
 import logo from "../../../assets/logo.png";
 import { Navigation } from "../../molecules";
@@ -40,7 +40,23 @@ const Logo = styled.img.attrs({
 `;
 
 function Header({ ...props }) {
-  const test = true;
+  const history = useHistory();
+  const location = useLocation();
+  const [toggleNav, setToggleNav] = useState(true);
+
+  const goMainPage = () => {
+    setToggleNav(true);
+    history.push("/");
+  };
+
+  const goMapPage = () => {
+    setToggleNav(false);
+    history.push("/map");
+  };
+
+  useEffect(() => {
+    location.pathname === "/" ? setToggleNav(true) : setToggleNav(false);
+  }, [toggleNav]);
 
   return (
     <StyledHeader>
@@ -48,8 +64,8 @@ function Header({ ...props }) {
         <Logo onClick={props.onClickLogo} />
       </Wrapper>
       <MiddleWrapper>
-        <Navigation iconType="feed" isSelected={test} />
-        <Navigation iconType="map" />
+        <Navigation iconType="feed" isSelected={toggleNav} onNavClick={goMainPage} />
+        <Navigation iconType="map" isSelected={!toggleNav} onNavClick={goMapPage} />
       </MiddleWrapper>
       <Wrapper>
         <Navigation iconType="createFeed" />


### PR DESCRIPTION
# [ESC 123] front header add event handler

## jira 칸반 링크
- [[Front] header add event handler](https://earth-saving-cleaner.atlassian.net/browse/ESC-123)

## 카드에서 구현 혹은 해결하려는 내용
- hader 클릭 이벤트 추가 및 라우터 이동 처리

## 테스트 방법
- 현재 렌더링 테스트만 진행된 상태입니다.

## 기타 사항
- 해당 기능은 jira 티켓에 없어서 새로운 티켓으로 생성했습니다.
