### PR TITLE
[ESC-137] Esc 137 front add address data when creating a feed and change feed location info

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -99,6 +99,7 @@ export const addPhotoToAWS = async (formData) => {
     //   },
     // });
     // return response.data;
+
     const response = {
       originalUrl:
         "https://earth-saving-cleaner.s3.ap-northeast-2.amazonaws.com/original/1644598340028KakaoTalk_Photo_2022-02-01-20-20-16.jpeg",
@@ -112,7 +113,7 @@ export const addPhotoToAWS = async (formData) => {
 };
 
 Geocode.setApiKey(process.env.REACT_APP_GOOGLE_MAP_API_KEY);
-Geocode.setLanguage("ko");
+Geocode.setLocationType("ROOFTOP");
 Geocode.enableDebug();
 
 // location: [37.488033333333334, 126.85566666666666]}

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -100,10 +100,16 @@ export const addPhotoToAWS = async (formData) => {
     // });
     // return response.data;
 
+    // const response = {
+    //   originalUrl:
+    //     "https://earth-saving-cleaner.s3.ap-northeast-2.amazonaws.com/original/1644598340028KakaoTalk_Photo_2022-02-01-20-20-16.jpeg",
+    //   url: "https://earth-saving-cleaner.s3.ap-northeast-2.amazonaws.com/thumb/1644598340028KakaoTalk_Photo_2022-02-01-20-20-16.jpeg",
+    // };
+
     const response = {
+      url: "https://earth-saving-cleaner.s3.ap-northeast-2.amazonaws.com/thumb/16440510063602180494_202118_264.jpeg",
       originalUrl:
-        "https://earth-saving-cleaner.s3.ap-northeast-2.amazonaws.com/original/1644598340028KakaoTalk_Photo_2022-02-01-20-20-16.jpeg",
-      url: "https://earth-saving-cleaner.s3.ap-northeast-2.amazonaws.com/thumb/1644598340028KakaoTalk_Photo_2022-02-01-20-20-16.jpeg",
+        "https://earth-saving-cleaner.s3.ap-northeast-2.amazonaws.com/original/16440510063602180494_202118_264.jpeg",
     };
     return response;
   } catch (err) {
@@ -113,7 +119,6 @@ export const addPhotoToAWS = async (formData) => {
 };
 
 Geocode.setApiKey(process.env.REACT_APP_GOOGLE_MAP_API_KEY);
-Geocode.setLocationType("ROOFTOP");
 Geocode.enableDebug();
 
 // location: [37.488033333333334, 126.85566666666666]}

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -128,7 +128,7 @@ export const getAddressFromLatLng = async (location) => {
 };
 
 export const addNewFeed = async (feedDetail) => {
-  const { pictureUrl, content, location, userInfo } = feedDetail;
+  const { pictureUrl, content, location, address, userInfo } = feedDetail;
 
   try {
     const response = await axios({
@@ -137,7 +137,7 @@ export const addNewFeed = async (feedDetail) => {
       headers: {
         authorization: `Bearer ${userInfo.token}`,
       },
-      data: { pictureUrl, content, location },
+      data: { pictureUrl, content, location, address },
     });
 
     return response;

--- a/src/components/organisms/FeedCard/index.js
+++ b/src/components/organisms/FeedCard/index.js
@@ -41,11 +41,7 @@ function FeedCard({ ...props }) {
 
   return (
     <Container>
-      <FeedHeader
-        url={props.avatarUrl}
-        nickname={props.nickname}
-        address="Ardyaloon, Western Australia 6725, Australia"
-      />
+      <FeedHeader url={props.avatarUrl} nickname={props.nickname} address={props.location} />
       <Img src={props.imageUrl} alt="feed image" width="100%" />
       <StatusWrapper>
         <IconWrapper>
@@ -77,6 +73,7 @@ FeedCard.propTypes = {
   comment: PropTypes.number,
   like: PropTypes.number,
   content: PropTypes.string,
+  location: PropTypes.string,
   onClickLikeIcon: PropTypes.func,
   onClickCommentIcon: PropTypes.func,
   isIconFilled: PropTypes.bool,
@@ -89,6 +86,7 @@ FeedCard.defaultProps = {
   comment: "",
   like: 0,
   content: 0,
+  location: "Ardyaloon, Western Australia 6725, Australia",
   onClickLikeIcon: noop,
   onClickCommentIcon: noop,
   isIconFilled: false,

--- a/src/components/organisms/ImageUpload/index.js
+++ b/src/components/organisms/ImageUpload/index.js
@@ -77,6 +77,7 @@ function ImageUpload(props) {
       }
     });
   }, []);
+
   useEffect(() => {
     const { getImage } = props;
 

--- a/src/components/organisms/ImageUpload/index.js
+++ b/src/components/organisms/ImageUpload/index.js
@@ -77,7 +77,6 @@ function ImageUpload(props) {
       }
     });
   }, []);
-
   useEffect(() => {
     const { getImage } = props;
 
@@ -86,7 +85,7 @@ function ImageUpload(props) {
       locationFromMeta: [latitude, longitude],
     };
 
-    if (resizedImageUrl && latitude && longitude) {
+    if (resizedImageUrl) {
       getImage(imageDetail);
     }
   }, [resizedImageUrl, latitude, longitude]);

--- a/src/components/organisms/NewFeed/index.js
+++ b/src/components/organisms/NewFeed/index.js
@@ -141,6 +141,7 @@ function NewFeed({ onClickModalClose }) {
       pictureUrl: [pictureUrl],
       content,
       location: [location[1], location[0]],
+      address,
       userInfo,
     };
 

--- a/src/components/organisms/NewFeed/index.js
+++ b/src/components/organisms/NewFeed/index.js
@@ -6,7 +6,7 @@ import { useHistory } from "react-router-dom";
 import styled from "styled-components";
 
 import GooglePlacesAutocomplete, { geocodeByAddress, getLatLng } from "react-google-places-autocomplete";
-import { noop } from "lodash";
+import { add, noop } from "lodash";
 
 import { getAddressFromLatLng, addNewFeed } from "../../../api";
 import { Icon, Textarea } from "../../atoms";
@@ -90,6 +90,11 @@ function NewFeed({ onClickModalClose }) {
 
   useEffect(() => {
     const getAddress = async () => {
+      if (inputAddress) {
+        setAddress(inputAddress.label);
+        return;
+      }
+
       try {
         const addressFromPhoto = await getAddressFromLatLng(location);
 
@@ -102,7 +107,7 @@ function NewFeed({ onClickModalClose }) {
     if (pictureUrl) {
       getAddress();
     }
-  }, [pictureUrl]);
+  }, [location]);
 
   useEffect(() => {
     const getCoordinates = async () => {
@@ -121,20 +126,28 @@ function NewFeed({ onClickModalClose }) {
 
     if (inputAddress) {
       getCoordinates();
+      setAddress(inputAddress.label);
     }
   }, [inputAddress]);
 
   useEffect(() => {
-    if (!photoAddress && !inputAddress) {
+    if (location[1] === 0) {
+      if (!photoAddress && !inputAddress) {
+        setAddress("Please enter your address");
+      }
+    }
+
+    if (location[1] !== 0) {
+      if (photoAddress) {
+        setAddress(photoAddress);
+        return;
+      }
+
       setAddress("Please enter your address");
     }
 
-    if (photoAddress) {
-      setAddress(photoAddress);
-    }
-
-    if (!photoAddress && inputAddress) {
-      setAddress(inputAddress);
+    if (inputAddress) {
+      setAddress(inputAddress.label);
     }
   }, [address, photoAddress, inputAddress]);
 

--- a/src/components/organisms/NewFeed/index.js
+++ b/src/components/organisms/NewFeed/index.js
@@ -6,7 +6,7 @@ import { useHistory } from "react-router-dom";
 import styled from "styled-components";
 
 import GooglePlacesAutocomplete, { geocodeByAddress, getLatLng } from "react-google-places-autocomplete";
-import { add, noop } from "lodash";
+import { noop } from "lodash";
 
 import { getAddressFromLatLng, addNewFeed } from "../../../api";
 import { Icon, Textarea } from "../../atoms";
@@ -131,24 +131,22 @@ function NewFeed({ onClickModalClose }) {
   }, [inputAddress]);
 
   useEffect(() => {
-    if (location[1] === 0) {
-      if (!photoAddress && !inputAddress) {
-        setAddress("Please enter your address");
-      }
-    }
-
-    if (location[1] !== 0) {
-      if (photoAddress) {
-        setAddress(photoAddress);
-        return;
-      }
-
+    if (location[1] === 0 && !photoAddress && !inputAddress) {
       setAddress("Please enter your address");
+      return;
     }
 
     if (inputAddress) {
       setAddress(inputAddress.label);
+      return;
     }
+
+    if (location[1] !== 0 && photoAddress) {
+      setAddress(photoAddress);
+      return;
+    }
+
+    setAddress("Please enter your address");
   }, [address, photoAddress, inputAddress]);
 
   const handleNewFeedSave = async () => {

--- a/src/components/organisms/NewFeed/index.js
+++ b/src/components/organisms/NewFeed/index.js
@@ -79,6 +79,7 @@ function NewFeed({ onClickModalClose }) {
 
   const getImage = (data) => {
     const { imageUrl, locationFromMeta } = data;
+
     setPictureUrl(imageUrl);
     setLocation(locationFromMeta);
   };
@@ -91,6 +92,7 @@ function NewFeed({ onClickModalClose }) {
     const getAddress = async () => {
       try {
         const addressFromPhoto = await getAddressFromLatLng(location);
+
         setPhotoAddress(addressFromPhoto.slice(5));
       } catch (err) {
         console.error(err);
@@ -108,7 +110,7 @@ function NewFeed({ onClickModalClose }) {
         const response = await geocodeByAddress(String(inputAddress));
         const result = await getLatLng(response[0]);
 
-        setLocation(result);
+        setLocation([result.lat, result.lng]);
 
         return result;
       } catch (err) {

--- a/src/components/pages/MainPage/index.js
+++ b/src/components/pages/MainPage/index.js
@@ -120,13 +120,14 @@ function MainPage() {
 
   useEffect(() => {
     const fetchFeed = async () => {
-      const { author, comment, content, image, like, location } = await getFeed(id);
+      const { author, comment, content, image, like, address } = await getFeed(id);
 
       setFeedInfo({
         author,
         content,
         like,
         image: image[0],
+        address,
       });
       setCommentList(comment);
     };
@@ -147,7 +148,7 @@ function MainPage() {
           {isLoading && <Text>Loding...</Text>}
           {feeds &&
             feeds?.data.map((feed) => {
-              const { _id, author, content, comment, image, like, location } = feed;
+              const { _id, author, content, comment, image, like, address } = feed;
               return (
                 <FeedCard
                   key={_id}
@@ -158,7 +159,7 @@ function MainPage() {
                   comment={comment.length}
                   like={like.length}
                   content={content}
-                  location={location}
+                  location={address}
                   onClickLikeIcon={userId ? handleLikeIconClick : sendToLogin}
                   onClickCommentIcon={() => handleCommentIconClick(_id)}
                   isIconFilled={[...feed.like].includes(userId)}


### PR DESCRIPTION
# [[ESC-137]] {front add address data when creating a feed and change feed location info}
 [173] 피드 메인 > 실제 피드 주소 노출 로직 추가
## jira 칸반 링크

- [[Front] Add address data when creating a feed and change feed location info](https://earth-saving-cleaner.atlassian.net/browse/ESC-137)

## 카드에서 구현 혹은 해결하려는 내용
- 피드 메인 > 이미지 상단 주소 노출 로직 추가
-피드 생성 > 언어설정 ko => en (default) 로 수정

## 테스트 방법
- yarn start
-
## 기타 사항
- 


[ESC-137]: https://earth-saving-cleaner.atlassian.net/browse/ESC-137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ