### PR TITLE
[ESC-176] update: avatar default image url

### DIFF
--- a/src/components/atoms/Avatar/index.js
+++ b/src/components/atoms/Avatar/index.js
@@ -47,7 +47,7 @@ Avatar.propTypes = {
 };
 
 Avatar.defaultProps = {
-  url: "https://lh3.googleusercontent.com/a/AATXAJzdJ5gTfflTC1--vXDDRH1n-wX7NQ9mJRViLtgc=s96-c",
+  url: "https://lh3.googleusercontent.com/ogw/ADea4I4JcqTQgVPY1LqlhGSA1AE5xeNzqAMXv1NbP2S6=s200-c-mo",
   size: "5rem",
   width: "5rem",
   height: "5rem",

--- a/src/components/organisms/UserCard/index.js
+++ b/src/components/organisms/UserCard/index.js
@@ -56,7 +56,7 @@ UserCard.propTypes = {
 
 UserCard.defaultProps = {
   url: "https://static01.nyt.com/images/2021/09/14/science/07CAT-STRIPES/07CAT-STRIPES-mediumSquareAt3X-v2.jpg",
-  avatarImage: "https://lh3.googleusercontent.com/a/AATXAJzdJ5gTfflTC1--vXDDRH1n-wX7NQ9mJRViLtgc=s96-c",
+  avatarImage: "https://lh3.googleusercontent.com/ogw/ADea4I4JcqTQgVPY1LqlhGSA1AE5xeNzqAMXv1NbP2S6=s200-c-mo",
   onClickCleanButton: noop,
 };
 


### PR DESCRIPTION
# [ESC 176] update avatar default image url

## jira 칸반 링크
- [update avatar default image url](https://earth-saving-cleaner.atlassian.net/browse/ESC-176)

## 카드에서 구현 혹은 해결하려는 내용
- avatar default prop url 변경